### PR TITLE
Ability to run tests in Parallel

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,6 +38,19 @@ module.exports = function (grunt) {
 							"yetAnotherKey": 123
 						}
 
+					},
+					{
+						"description": "many",
+						"mocha": {
+							"parallelType": "file"
+						},
+						"env1": {
+							"anotherKey": "BLERG"
+						},
+						"env2": {
+							"yetAnotherKey": 123
+						}
+
 					}
 				],
 				mocha: {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,12 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "async": "^0.9.0",
+    "lodash": "^2.4.1",
     "mocha": "*"
   },
   "devDependencies": {
+    "chai": "^1.9.2",
     "grunt": "0.4.x",
     "grunt-contrib-jshint": "0.1.x",
     "xunit-file": "*"

--- a/tasks/process-loop.js
+++ b/tasks/process-loop.js
@@ -1,0 +1,112 @@
+var spawn = require("child_process").spawn
+var path  = require('path')
+var util  = require('util')
+var _     = require('lodash')
+var async = require('async')
+
+/**
+  * Main level.  Grunt is injected
+  * from the task.  _spawn is injected
+  * to help with tests.
+  */
+module.exports = function exports (grunt, _spawn) {
+  // injection here
+  if (_spawn) {
+    spawn = _spawn
+  }
+  // Give us a function that will work with async
+  return function processLoop(op, cb) {
+    // rip up the op into vars
+    var filesSrc                      = op.filesSrc
+      , mocha_path                    = op.mocha_path
+      , reportLocation                = op.reportLocation
+      , localopts                     = op.localopts
+      , localOtherOptionsStringified  = op.localOtherOptionsStringified
+      , itLabel                       = op.itLabel
+      , localMochaOptions             = op.localMochaOptions
+
+    var limit         = localMochaOptions.limit || 5
+    var parallelType  = localMochaOptions.parallelType
+    var env           = _.merge(process.env, localOtherOptionsStringified)
+
+    // pick a way to split up the work
+    if (parallelType === 'directory') {   // async by directory
+      async
+        .mapLimit(_.chain(filesSrc)
+                    // group by the directory path
+                    .groupBy(function(file) {
+                      return path.dirname(file)
+                    })
+                    // rework the data into something async will be ok with
+                    .map(function(files, dir) {
+                      return [files, dir]
+                    })
+                    .value()
+                , limit
+                , function(args, _cb) {
+                    // update the label, do the work
+                    work(itLabel + ':' + args[1].replace('/', '-')
+                        , args[0]
+                        , _.cloneDeep(env)
+                        , _.cloneDeep(localopts)
+                        , _cb)
+                }
+                , cb)
+    } else if (parallelType === 'file') { // async by file
+      async
+        .mapLimit(filesSrc
+                , limit
+                , function(file, _cb) {
+                    // update the label, do the work
+                    work(itLabel + ':' + file.replace('/', '-')
+                        , [file]
+                        , _.cloneDeep(env)
+                        , _.cloneDeep(localopts)
+                        , _cb)
+                }
+                , cb)
+    }  else {                             // not async
+      work(itLabel, filesSrc, env, localopts
+          , function(err, result) {
+              // to normalize results, we wrap this one in an
+              // array, even though there is only one.
+              cb(err, [result])
+            })
+    }
+
+    function work(_itLabel, _filesSrc, _env, _op, _cb) {
+
+      // inform the world that we are going to start
+      grunt.log.writeln("[grunt-loop-mocha] iteration: ", _itLabel);
+
+      // update the reporter file
+      if (localMochaOptions.reporter === "xunit-file") {
+        // Only update the env for the spawned process.
+        _env.XUNIT_FILE = reportLocation + "/xunit-" + _itLabel + ".xml";
+        grunt.log.writeln("[grunt-loop-mocha] xunit output: ", _env.XUNIT_FILE);
+      }
+
+      // push the files into localopts
+      _filesSrc.forEach(function (el) {
+        _op.push(el);
+      });
+
+      // more notify
+      grunt.log.writeln("[grunt-loop-mocha] mocha argv: ", _op.toString());
+
+      // start a process
+      var child = spawn(mocha_path
+                      , _op
+                      , {env: _env});
+
+      // pipe the output (in paralell this is going to be noisey)
+      child.stdout.pipe(process.stdout)
+      child.stderr.pipe(process.stderr)
+
+      // report back the outcome
+      child.on('close', function (code) {
+        _cb(null, [code, _itLabel])
+      });
+    }
+  }
+}

--- a/test/process-loop-test.js
+++ b/test/process-loop-test.js
@@ -1,0 +1,155 @@
+"use strict";
+describe("Process Loop", function() {
+  var process       = require('../tasks/process-loop.js')
+  var noop          = function noop(){}
+  var expect        = require('chai').expect
+  var EventEmitter  = require('events').EventEmitter
+
+  it("should call spawn once", function(done) {
+
+    var testMe = process({log:{writeln: noop}}
+                        , function(path, op, env) {
+                            // test here
+                            expect(path)
+                              .to.equal('some/mocha/path')
+                            expect(op)
+                              .to.deep.equal(['other', 'options', 'one', 'two'])
+                            expect(env)
+                              .to.have.deep.property('env.opt')
+                              .that.equals('"process"')
+                            expect(env)
+                              .to.have.deep.property('env.XUNIT_FILE')
+                              .that.equals('./a/report/location/xunit-Test Label.xml')
+
+                            // We need to hand some stuff back...
+                             var ee = new EventEmitter()
+                            ee.stdout = {pipe:noop}
+                            ee.stderr = {pipe:noop}
+                            setTimeout(function() {
+                              ee.emit('close', 0)
+                            }, 1)
+                            return ee
+                        })
+
+    testMe({filesSrc                    : ['one', 'two']
+          , mocha_path                  : 'some/mocha/path'
+          , reportLocation              : './a/report/location'
+          , localopts                   : ['other', 'options']
+          , localOtherOptionsStringified: {opt:'"process"'}
+          , itLabel                     : 'Test Label'
+          , localMochaOptions           : {reporter         : "xunit-file"
+                                          , reportLocation  : "/some/path"}}
+        , function(err, results) {
+            expect(results)
+              .to.deep.equal([[ 0, 'Test Label' ]])
+            done()
+          })
+  })
+
+  it("should call spawn once for each file", function(done) {
+    var testMe = process({log:{writeln: noop}}
+                        , function(path, op, env) {
+                            // test here
+                            expect(path)
+                              .to.equal('some/mocha/path')
+                            expect(env)
+                              .to.have.deep.property('env.opt')
+                              .that.equals('"process"')
+
+                            if (op.indexOf('one') >= 0) {
+                              expect(op)
+                                .to.deep.equal(['other', 'options', 'one'])
+                              expect(env)
+                                .to.have.deep.property('env.XUNIT_FILE')
+                                .that.equals('./a/report/location/xunit-Test Label:one.xml')
+
+                            } else if (op.indexOf('two') >= 0) {
+                              expect(op)
+                                .to.deep.equal(['other', 'options', 'two'])
+                              expect(env)
+                                .to.have.deep.property('env.XUNIT_FILE')
+                                .that.equals('./a/report/location/xunit-Test Label:two.xml')
+                            } else {
+                              expect(true).to.not.be.true
+                            }
+
+                            // We need to hand some stuff back...
+                             var ee = new EventEmitter()
+                            ee.stdout = {pipe:noop}
+                            ee.stderr = {pipe:noop}
+                            setTimeout(function() {
+                              ee.emit('close', 0)
+                            }, 1)
+                            return ee
+                        })
+
+    testMe({filesSrc                    : ['one', 'two']
+          , mocha_path                  : 'some/mocha/path'
+          , reportLocation              : './a/report/location'
+          , localopts                   : ['other', 'options']
+          , localOtherOptionsStringified: {opt:'"process"'}
+          , itLabel                     : 'Test Label'
+          , localMochaOptions           : {reporter         : "xunit-file"
+                                          , reportLocation  : "/some/path"
+                                          , parallelType    : "file"}}
+        , function(err, results) {
+            expect(results)
+              .to.deep.equal([ [ 0, 'Test Label:one' ], [ 0, 'Test Label:two' ] ])
+            done()
+          })
+  })
+
+  it("should call spawn once for each directory", function(done) {
+    var testMe = process({log:{writeln: noop}}
+                        , function(path, op, env) {
+                            // test here
+                            expect(path)
+                              .to.equal('some/mocha/path')
+                            expect(env)
+                              .to.have.deep.property('env.opt')
+                              .that.equals('"process"')
+
+                            if (op.indexOf('/dir1/one') >= 0) {
+                              expect(op)
+                                .to.deep.equal(['other', 'options', '/dir1/one', '/dir1/two'])
+                              expect(env)
+                                .to.have.deep.property('env.XUNIT_FILE')
+                                .that.equals('./a/report/location/xunit-Test Label:-dir1.xml')
+
+                            } else if (op.indexOf('/dir2/one') >= 0) {
+                              expect(op)
+                                .to.deep.equal(['other', 'options', '/dir2/one', '/dir2/two'])
+                              expect(env)
+                                .to.have.deep.property('env.XUNIT_FILE')
+                                .that.equals('./a/report/location/xunit-Test Label:-dir2.xml')
+                            } else {
+                              expect(true).to.not.be.true
+                            }
+
+                            // We need to hand some stuff back...
+                             var ee = new EventEmitter()
+                            ee.stdout = {pipe:noop}
+                            ee.stderr = {pipe:noop}
+                            setTimeout(function() {
+                              ee.emit('close', 0)
+                            }, 1)
+                            return ee
+                        })
+
+    testMe({filesSrc                    : ['/dir1/one', '/dir1/two'
+                                          , '/dir2/one', '/dir2/two']
+          , mocha_path                  : 'some/mocha/path'
+          , reportLocation              : './a/report/location'
+          , localopts                   : ['other', 'options']
+          , localOtherOptionsStringified: {opt:'"process"'}
+          , itLabel                     : 'Test Label'
+          , localMochaOptions           : {reporter         : "xunit-file"
+                                          , reportLocation  : "/some/path"
+                                          , parallelType    : "directory"}}
+        , function(err, results) {
+            expect(results)
+              .to.deep.equal([ [ 0, 'Test Label:-dir1' ], [ 0, 'Test Label:-dir2' ] ])
+            done()
+          })
+  })
+})


### PR DESCRIPTION
Test can be run in Paralle, where each test file is run in it's own Mocha process.

Intremented by 2 new options
--paralledType === file || directory || false
--limit

The parallel type is how the mocha processes are broken up, by file or directory.

All the heavy lifting is done in process-loop.js.

Finaly, I updated the Grunt dependancies for async and lodash
