### PR TITLE
Support retries on failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ any supported mocha command line argument is accepted.
 * parallel (optional: defaults to false): To engage a parallel testing ability, specify parallel.type = "file|directory". Optionally specify parallel.limit to limit the concurrent running processes
 * reportLocation (required if using xunit-file reporter): specify where xunit report files should be written. Note: if you are using "xunit-file" as your reporter, you need to add it to your package.json
 * noFail (optional: defaults to false): If true, the task will exit as zero regardless of any mocha test failures
+* retries (optional: defaults to 0): To re-run mocha if there is any test failure
 
 ### iterations options
 Array of JSON objects. mocha will loop for each item, using its properties for the mocha run

--- a/tasks/loop-mocha.js
+++ b/tasks/loop-mocha.js
@@ -123,7 +123,7 @@ module.exports = function (grunt) {
       // spill off the processes.  This can be quite a few.
       // the results will be in the form
       // [[returnCode, itterationName], ...]
-      require('./process-loop.js')(grunt)({
+      require('./process-loop.js')(grunt, null, loopOptions)({
           filesSrc: filesSrc, mocha_path: mocha_path, reportLocation: reportLocation, localopts: localopts, localOtherOptionsStringified: localOtherOptionsStringified, itLabel: itLabel, localMochaOptions: localMochaOptions, loopOptions: loopOptions
         }
         , cb);


### PR DESCRIPTION
**Issues:**

Mocha retries option has a few limitations:
* Does not retry if error is thrown in before/after[Each] statements
* Retry only the failed test case, it does not re-run the whole spec
* For test case that depends on other previous test cases to run, retrying just the failed test case will not help

**Requirement:**

Loopmocha supports parallel execution, should any of the mocha runs failed, re-run the mocha execution up to the number of retries option.

It will come in handy for ECI 2 in PP, considering stage env is often not stable.